### PR TITLE
Refactor endpoint classes and registration mechanism

### DIFF
--- a/src/DigitalRightsManagement.Api/Endpoints/ProductEndpoints.cs
+++ b/src/DigitalRightsManagement.Api/Endpoints/ProductEndpoints.cs
@@ -2,19 +2,20 @@
 using DigitalRightsManagement.Application.ProductAggregate;
 using DigitalRightsManagement.Application.UserAggregate;
 using DigitalRightsManagement.Domain.ProductAggregate;
+using DigitalRightsManagement.Infrastructure.Endpoints;
 using DigitalRightsManagement.Infrastructure.Identity;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DigitalRightsManagement.Api.Endpoints;
 
-internal static class ProductEndpoints
+internal class ProductEndpoints : EndpointGroupBase
 {
-    public static void MapProductEndpoints(this WebApplication app)
-    {
-        var group = app.MapGroup("/products")
-            .WithTags("Products");
+    protected override string GroupName => "Products";
+    protected override string BaseRoute => "/products";
 
+    protected override RouteGroupBuilder ConfigureEndpoints(RouteGroupBuilder group)
+    {
         group.MapGet("/", GetProducts)
             .WithName("Get Products")
             .WithSummary("Get the projects of a user")
@@ -56,6 +57,8 @@ internal static class ProductEndpoints
             .WithDescription("Allows a manager to mark their product as obsolete.")
             .ProducesDefault()
             .RequireAuthorization(Policies.IsManager);
+
+        return group;
     }
 
     private static async Task<IResult> GetProducts([FromServices] IMediator mediator, CancellationToken ct)

--- a/src/DigitalRightsManagement.Api/Endpoints/UserEndpoints.cs
+++ b/src/DigitalRightsManagement.Api/Endpoints/UserEndpoints.cs
@@ -1,19 +1,20 @@
 ﻿using Ardalis.Result.AspNetCore;
 using DigitalRightsManagement.Application.UserAggregate;
 using DigitalRightsManagement.Domain.UserAggregate;
+using DigitalRightsManagement.Infrastructure.Endpoints;
 using DigitalRightsManagement.Infrastructure.Identity;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DigitalRightsManagement.Api.Endpoints;
 
-internal static class UserEndpoints
+internal class UserEndpoints : EndpointGroupBase
 {
-    public static void MapUserEndpoints(this WebApplication app)
-    {
-        var group = app.MapGroup("/users/")
-            .WithTags("Users");
+    protected override string GroupName => "Users";
+    protected override string BaseRoute => "/users";
 
+    protected override RouteGroupBuilder ConfigureEndpoints(RouteGroupBuilder group)
+    {
         group.MapGet("/me", GetCurrentUserInformation)
             .WithName("GetCurrentUser")
             .WithSummary("Get current user information")
@@ -34,6 +35,8 @@ internal static class UserEndpoints
             .WithDescription("Allows an user to change his/her e-mail address.")
             .ProducesDefault()
             .RequireAuthorization();
+
+        return group;
     }
 
     private static async Task<IResult> GetCurrentUserInformation([FromServices] IMediator mediator, CancellationToken ct)

--- a/src/DigitalRightsManagement.Api/Program.cs
+++ b/src/DigitalRightsManagement.Api/Program.cs
@@ -1,7 +1,7 @@
 using DigitalRightsManagement.Api;
-using DigitalRightsManagement.Api.Endpoints;
 using DigitalRightsManagement.Infrastructure;
 using DigitalRightsManagement.Infrastructure.Authentication;
+using DigitalRightsManagement.Infrastructure.Endpoints;
 using DigitalRightsManagement.Infrastructure.Identity;
 using DigitalRightsManagement.ServiceDefaults;
 
@@ -37,7 +37,6 @@ app.UseExceptionHandler();
 app.UseAuthentication();
 app.UseAuthorization();
 
-app.MapUserEndpoints();
-app.MapProductEndpoints();
+app.MapEndpointModules(typeof(Program).Assembly);
 
 await app.RunAsync();

--- a/src/DigitalRightsManagement.Infrastructure/Endpoints/EndpointDependencyInjection.cs
+++ b/src/DigitalRightsManagement.Infrastructure/Endpoints/EndpointDependencyInjection.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.AspNetCore.Builder;
+using System.Reflection;
+
+namespace DigitalRightsManagement.Infrastructure.Endpoints;
+
+/// <summary>
+/// Extension method to register all endpoints from IEndpointModule implementations.
+/// </summary>
+public static class EndpointDependencyInjection
+{
+    /// <summary>
+    /// Maps all endpoint modules found in the specified assemblies
+    /// </summary>
+    /// <param name="app">The web application</param>
+    /// <param name="assembly">The first assembly to scan for endpoint modules</param>
+    /// <param name="additionalAssemblies">Additional assemblies to scan for endpoint modules</param>
+    /// <returns>The web application for chaining</returns>
+    public static WebApplication MapEndpointModules(
+        this WebApplication app,
+        Assembly assembly,
+        params Assembly[] additionalAssemblies)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+        ArgumentNullException.ThrowIfNull(assembly);
+
+        var assemblies = new[] { assembly }.Concat(additionalAssemblies ?? []);
+        var endpointModules = DiscoverEndpointModules(assemblies);
+
+        foreach (var module in endpointModules)
+        {
+            module.MapEndpoints(app);
+        }
+
+        return app;
+    }
+
+    private static IEnumerable<IEndpointModule> DiscoverEndpointModules(IEnumerable<Assembly> assemblies)
+    {
+        var moduleType = typeof(IEndpointModule);
+
+        return assemblies
+            .SelectMany(assembly => assembly.GetTypes())
+            .Where(type => moduleType.IsAssignableFrom(type) && type is { IsAbstract: false, IsInterface: false })
+            .Select(Activator.CreateInstance)
+            .Cast<IEndpointModule>();
+    }
+}

--- a/src/DigitalRightsManagement.Infrastructure/Endpoints/EndpointGroupBase .cs
+++ b/src/DigitalRightsManagement.Infrastructure/Endpoints/EndpointGroupBase .cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace DigitalRightsManagement.Infrastructure.Endpoints;
+
+/// <summary>
+/// Represents a group of related endpoints.
+/// </summary>
+public abstract class EndpointGroupBase : IEndpointModule
+{
+    protected abstract string GroupName { get; }
+    protected abstract string BaseRoute { get; }
+
+    public IEndpointRouteBuilder MapEndpoints(IEndpointRouteBuilder builder)
+    {
+        var group = builder.MapGroup(BaseRoute)
+            .WithTags(GroupName);
+
+        ConfigureEndpoints(group);
+
+        return builder;
+    }
+
+    protected abstract RouteGroupBuilder ConfigureEndpoints(RouteGroupBuilder group);
+}

--- a/src/DigitalRightsManagement.Infrastructure/Endpoints/IEndpointModule.cs
+++ b/src/DigitalRightsManagement.Infrastructure/Endpoints/IEndpointModule.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.AspNetCore.Routing;
+
+namespace DigitalRightsManagement.Infrastructure.Endpoints;
+
+/// <summary>
+/// Base interface for all endpoint modules.
+/// </summary>
+internal interface IEndpointModule
+{
+    IEndpointRouteBuilder MapEndpoints(IEndpointRouteBuilder builder);
+}


### PR DESCRIPTION
Refactor endpoint classes and registration mechanism

Refactored `ProductEndpoints` and `UserEndpoints` from static to non-static classes inheriting from `EndpointGroupBase` for better organization. Replaced explicit mapping methods with an overridden `ConfigureEndpoints` method to enhance modularity. Updated `Program.cs` to utilize `MapEndpointModules` for dynamic endpoint registration. Introduced `EndpointDependencyInjection` for module discovery, along with an abstract `EndpointGroupBase` class and `IEndpointModule` interface to standardize endpoint definitions. Overall, improved the structure and scalability of endpoint management.