### PR TITLE
Switch to Shouldly for assertions in tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,6 +37,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.0.1" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.5.0.109200" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.extensibility.core" Version="2.9.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
     <PackageVersion Include="Bogus" Version="35.6.1" />
     <PackageVersion Include="CommunityToolkit.Diagnostics" Version="8.4.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.3" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.5.1" />
     <PackageVersion Include="MediatR" Version="12.4.1" />
     <PackageVersion Include="MediatR.Contracts" Version="2.0.1" />
@@ -27,14 +27,14 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.1.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.10.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.10.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.0.1" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.0.4" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.5.0.109200" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,8 +13,6 @@
     <PackageVersion Include="Bogus" Version="35.6.1" />
     <PackageVersion Include="CommunityToolkit.Diagnostics" Version="8.4.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.3" />
-    <PackageVersion Include="FluentAssertions" Version="8.0.0" />
-    <PackageVersion Include="FluentAssertions.Analyzers" Version="0.34.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.5.1" />
     <PackageVersion Include="MediatR" Version="12.4.1" />
     <PackageVersion Include="MediatR.Contracts" Version="2.0.1" />

--- a/tests/DigitalRightsManagement.IntegrationTests/ProductTests.cs
+++ b/tests/DigitalRightsManagement.IntegrationTests/ProductTests.cs
@@ -3,8 +3,8 @@ using DigitalRightsManagement.Application.ProductAggregate;
 using DigitalRightsManagement.Domain.ProductAggregate;
 using DigitalRightsManagement.Domain.UserAggregate;
 using DigitalRightsManagement.Tests.Shared.Factories;
-using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Shouldly;
 using System.Net.Http.Json;
 
 namespace DigitalRightsManagement.IntegrationTests;
@@ -21,7 +21,7 @@ public sealed class ProductTests(ApiFixture fixture) : ApiIntegrationTestsBase(f
         var response = await GetHttpClient(managerWithProducts).GetAsync("products");
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var products = await response.Content.ReadFromJsonAsync<ProductDto[]>();
 
         var productNames = await DbContext.Products
@@ -29,8 +29,8 @@ public sealed class ProductTests(ApiFixture fixture) : ApiIntegrationTestsBase(f
             .Select(p => p.Name)
             .ToArrayAsync();
 
-        products.Should().NotBeNullOrEmpty();
-        products.Select(p => p.Name).Should().BeEquivalentTo(productNames);
+        products.ShouldNotBeEmpty();
+        products.Select(p => p.Name).ToArray().ShouldBeEquivalentTo(productNames);
     }
 
     [Fact]
@@ -50,20 +50,20 @@ public sealed class ProductTests(ApiFixture fixture) : ApiIntegrationTestsBase(f
         var response = await GetHttpClient(manager).PostAsJsonAsync("/products/create", createProductDto);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var createdProductId = await response.Content.ReadFromJsonAsync<Guid>();
-        createdProductId.Should().NotBeEmpty();
+        createdProductId.ShouldNotBe(Guid.Empty);
 
         var product = await DbContext.Products.FindAsync(createdProductId);
-        product.Should().NotBeNull();
-        product.Name.Should().Be(productName);
-        product.Description.Should().Be(productDescription);
-        product.Price.Amount.Should().Be(productPrice);
-        product.Price.Currency.Should().Be(productCurrency);
+        product.ShouldNotBeNull();
+        product.Name.ShouldBe(productName);
+        product.Description.ShouldBe(productDescription);
+        product.Price.Amount.ShouldBe(productPrice);
+        product.Price.Currency.ShouldBe(productCurrency);
 
-        manager = await DbContext.Users.FindAsync([manager.Id]);
-        manager.Should().NotBeNull();
-        manager.Products.Should().Contain(productId => productId == createdProductId);
+        manager = await DbContext.Users.FindAsync(manager.Id);
+        manager.ShouldNotBeNull();
+        manager.Products.ShouldContain(productId => productId == createdProductId);
     }
 
     [Fact]
@@ -83,12 +83,12 @@ public sealed class ProductTests(ApiFixture fixture) : ApiIntegrationTestsBase(f
         var response = await GetHttpClient(manager).PutAsJsonAsync($"/products/{productId}/price", updatePriceDto);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
 
         var updatedProduct = await DbContext.Products.FindAsync(productId);
-        updatedProduct.Should().NotBeNull();
-        updatedProduct.Price.Amount.Should().Be(newPrice);
-        updatedProduct.Price.Currency.Should().Be(newCurrency);
+        updatedProduct.ShouldNotBeNull();
+        updatedProduct.Price.Amount.ShouldBe(newPrice);
+        updatedProduct.Price.Currency.ShouldBe(newCurrency);
     }
 
     [Fact]
@@ -106,11 +106,11 @@ public sealed class ProductTests(ApiFixture fixture) : ApiIntegrationTestsBase(f
         var response = await GetHttpClient(manager).PutAsJsonAsync($"/products/{productId}/description", updatePriceDto);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
 
         var updatedProduct = await DbContext.Products.FindAsync(productId);
-        updatedProduct.Should().NotBeNull();
-        updatedProduct.Description.Should().Be(newDescription);
+        updatedProduct.ShouldNotBeNull();
+        updatedProduct.Description.ShouldBe(newDescription);
     }
 
     [Fact]
@@ -124,11 +124,11 @@ public sealed class ProductTests(ApiFixture fixture) : ApiIntegrationTestsBase(f
         var response = await GetHttpClient(manager).PostAsync($"/products/{product.Id}/publish", null);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
 
         await DbContext.Entry(product).ReloadAsync();
-        product.Should().NotBeNull();
-        product.Status.Should().Be(ProductStatus.Published);
+        product.ShouldNotBeNull();
+        product.Status.ShouldBe(ProductStatus.Published);
     }
 
     [Fact]
@@ -142,10 +142,10 @@ public sealed class ProductTests(ApiFixture fixture) : ApiIntegrationTestsBase(f
         var response = await GetHttpClient(manager).PostAsync($"/products/{product.Id}/obsolete", null);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
 
         await DbContext.Entry(product).ReloadAsync();
-        product.Should().NotBeNull();
-        product.Status.Should().Be(ProductStatus.Obsolete);
+        product.ShouldNotBeNull();
+        product.Status.ShouldBe(ProductStatus.Obsolete);
     }
 }

--- a/tests/DigitalRightsManagement.IntegrationTests/UserTests.cs
+++ b/tests/DigitalRightsManagement.IntegrationTests/UserTests.cs
@@ -2,8 +2,8 @@
 using DigitalRightsManagement.Application.UserAggregate;
 using DigitalRightsManagement.Domain.UserAggregate;
 using DigitalRightsManagement.Tests.Shared.Factories;
-using FluentAssertions;
 using System.Net.Http.Json;
+using Shouldly;
 
 namespace DigitalRightsManagement.IntegrationTests;
 
@@ -19,13 +19,13 @@ public sealed class UserTests(ApiFixture fixture) : ApiIntegrationTestsBase(fixt
         var response = await GetHttpClient(user).GetAsync("/users/me");
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var userDto = await response.Content.ReadFromJsonAsync<UserDto>();
-        userDto.Should().NotBeNull();
-        userDto.Id.Should().Be(user.Id);
-        userDto.Username.Should().Be(user.Username);
-        userDto.Email.Should().Be(user.Email);
-        userDto.Role.Should().Be(user.Role);
+        userDto.ShouldNotBeNull();
+        userDto.Id.ShouldBe(user.Id);
+        userDto.Username.ShouldBe(user.Username);
+        userDto.Email.ShouldBe(user.Email);
+        userDto.Role.ShouldBe(user.Role);
     }
 
     [Fact]
@@ -42,11 +42,11 @@ public sealed class UserTests(ApiFixture fixture) : ApiIntegrationTestsBase(fixt
         var response = await GetHttpClient(admin).PostAsJsonAsync("users/change-role", changeRoleDto);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
 
         target = await DbContext.Users.FindAsync(target.Id);
-        target.Should().NotBeNull();
-        target.Role.Should().Be(desiredRole);
+        target.ShouldNotBeNull();
+        target.Role.ShouldBe(desiredRole);
     }
 
     [Fact]
@@ -62,10 +62,10 @@ public sealed class UserTests(ApiFixture fixture) : ApiIntegrationTestsBase(fixt
         var response = await GetHttpClient(user).PostAsJsonAsync("/users/change-email", changeEmailDto);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
 
         user = await DbContext.Users.FindAsync(user.Id);
-        user.Should().NotBeNull();
-        user.Email.Should().Be(newEmail);
+        user.ShouldNotBeNull();
+        user.Email.ShouldBe(newEmail);
     }
 }

--- a/tests/DigitalRightsManagement.Tests.Shared/DigitalRightsManagement.Tests.Shared.csproj
+++ b/tests/DigitalRightsManagement.Tests.Shared/DigitalRightsManagement.Tests.Shared.csproj
@@ -2,11 +2,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" />
-		<PackageReference Include="FluentAssertions" />
-		<PackageReference Include="FluentAssertions.Analyzers">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
 		<PackageReference Include="xunit.extensibility.core" />
 	</ItemGroup>
 

--- a/tests/DigitalRightsManagement.UnitTests/ProductAggregate/ProductTests.cs
+++ b/tests/DigitalRightsManagement.UnitTests/ProductAggregate/ProductTests.cs
@@ -5,7 +5,7 @@ using DigitalRightsManagement.Domain.UserAggregate;
 using DigitalRightsManagement.Tests.Shared.Factories;
 using DigitalRightsManagement.Tests.Shared.TestData;
 using DigitalRightsManagement.UnitTests.Common.Abstractions;
-using FluentAssertions;
+using Shouldly;
 
 namespace DigitalRightsManagement.UnitTests.ProductAggregate;
 
@@ -23,8 +23,9 @@ public sealed class ProductTests : UnitTestBase
         var result = Product.Create(_validProduct.Name, _validProduct.Description, _validProduct.Price, Guid.NewGuid(), emptyId);
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
-        result.ValidationErrors.Should().ContainSingle().Which.ErrorCode.Should().Contain("id");
+        result.IsInvalid().ShouldBeTrue();
+        result.ValidationErrors.ShouldHaveSingleItem()
+            .ErrorCode.ShouldContain("id");
     }
 
     [Theory, ClassData(typeof(EmptyStringTestData))]
@@ -35,8 +36,8 @@ public sealed class ProductTests : UnitTestBase
         var result = Product.Create(emptyName, _validProduct.Description, _validProduct.Price, Guid.NewGuid());
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
-        result.ValidationErrors.Should().ContainSingle().Which.ErrorCode.Should().Contain("name");
+        result.IsInvalid().ShouldBeTrue();
+        result.ValidationErrors.ShouldHaveSingleItem().ErrorCode.ShouldContain("name");
     }
 
     [Theory, ClassData(typeof(EmptyStringTestData))]
@@ -47,8 +48,8 @@ public sealed class ProductTests : UnitTestBase
         var result = Product.Create(_validProduct.Name, emptyDescription, _validProduct.Price, Guid.NewGuid());
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
-        result.ValidationErrors.Should().ContainSingle().Which.ErrorCode.Should().Contain("description");
+        result.IsInvalid().ShouldBeTrue();
+        result.ValidationErrors.ShouldHaveSingleItem().ErrorCode.ShouldContain("description");
     }
 
     [Theory]
@@ -61,8 +62,9 @@ public sealed class ProductTests : UnitTestBase
         var result = Price.Create(negativePrice, _validProduct.Price.Currency);
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
-        result.ValidationErrors.Should().ContainSingle().Which.ErrorCode.Should().Contain("price");
+        result.IsInvalid().ShouldBeTrue();
+        result.ValidationErrors.ShouldHaveSingleItem()
+            .ErrorCode.ShouldContain("price");
     }
 
     [Fact]
@@ -75,8 +77,9 @@ public sealed class ProductTests : UnitTestBase
         var result = Price.Create(1.00m, unknownCurrency);
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
-        result.ValidationErrors.Should().ContainSingle().Which.ErrorCode.Should().Contain("price");
+        result.IsInvalid().ShouldBeTrue();
+        result.ValidationErrors.ShouldHaveSingleItem()
+            .ErrorCode.ShouldContain("price");
     }
 
     [Fact]
@@ -89,8 +92,9 @@ public sealed class ProductTests : UnitTestBase
         var result = Product.Create(_validProduct.Name, _validProduct.Description, _validProduct.Price, emptyGuid);
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
-        result.ValidationErrors.Should().ContainSingle().Which.ErrorCode.Should().Contain("created-by");
+        result.IsInvalid().ShouldBeTrue();
+        result.ValidationErrors.ShouldHaveSingleItem()
+            .ErrorCode.ShouldContain("created-by");
     }
 
     [Fact]
@@ -103,19 +107,19 @@ public sealed class ProductTests : UnitTestBase
         var priceResult = Price.Create(zeroPrice, _validProduct.Price.Currency);
 
         // Assert
-        priceResult.IsSuccess.Should().BeTrue();
-        priceResult.Value.Amount.Should().Be(zeroPrice);
-        priceResult.Value.Currency.Should().Be(_validProduct.Price.Currency);
+        priceResult.IsSuccess.ShouldBeTrue();
+        priceResult.Value.Amount.ShouldBe(zeroPrice);
+        priceResult.Value.Currency.ShouldBe(_validProduct.Price.Currency);
 
         // Act
         var productResult = Product.Create(_validProduct.Name, _validProduct.Description, priceResult.Value, _validProduct.UserId);
 
         // Assert
-        productResult.IsSuccess.Should().BeTrue();
-        productResult.Value.Name.Should().Be(_validProduct.Name);
-        productResult.Value.Description.Should().Be(_validProduct.Description);
-        productResult.Value.Price.Amount.Should().Be(zeroPrice);
-        productResult.Value.Price.Currency.Should().Be(_validProduct.Price.Currency);
+        productResult.IsSuccess.ShouldBeTrue();
+        productResult.Value.Name.ShouldBe(_validProduct.Name);
+        productResult.Value.Description.ShouldBe(_validProduct.Description);
+        productResult.Value.Price.Amount.ShouldBe(zeroPrice);
+        productResult.Value.Price.Currency.ShouldBe(_validProduct.Price.Currency);
     }
 
     [Fact]
@@ -126,10 +130,10 @@ public sealed class ProductTests : UnitTestBase
         var result = Product.Create(_validProduct.Name, _validProduct.Description, _validProduct.Price, _validProduct.UserId);
 
         // Assert
-        result.IsSuccess.Should().BeTrue();
-        result.Value.Name.Should().Be(_validProduct.Name);
-        result.Value.Description.Should().Be(_validProduct.Description);
-        result.Value.Price.Should().Be(_validProduct.Price);
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Name.ShouldBe(_validProduct.Name);
+        result.Value.Description.ShouldBe(_validProduct.Description);
+        result.Value.Price.ShouldBe(_validProduct.Price);
     }
 
     [Fact]
@@ -140,8 +144,8 @@ public sealed class ProductTests : UnitTestBase
         var result = Product.Create(_validProduct.Name, _validProduct.Description, _validProduct.Price, _validProduct.UserId);
 
         // Assert
-        result.IsSuccess.Should().BeTrue();
-        result.Value.DomainEvents.Should().ContainSingle().Which.Should().BeOfType<ProductCreated>();
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<ProductCreated>();
     }
 
     [Fact]
@@ -156,7 +160,7 @@ public sealed class ProductTests : UnitTestBase
         product.UpdatePrice(manager.Id, newPrice, "reason");
 
         // Assert
-        product.Price.Should().Be(newPrice);
+        product.Price.ShouldBe(newPrice);
     }
 
     [Fact]
@@ -170,7 +174,7 @@ public sealed class ProductTests : UnitTestBase
         var result = product.UpdatePrice(Guid.Empty, newPrice, "reason");
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
+        result.IsInvalid().ShouldBeTrue();
     }
 
     [Fact]
@@ -185,7 +189,7 @@ public sealed class ProductTests : UnitTestBase
         var result = product.UpdatePrice(randomUserId, newPrice, "reason");
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
+        result.IsInvalid().ShouldBeTrue();
     }
 
     [Fact]
@@ -200,7 +204,7 @@ public sealed class ProductTests : UnitTestBase
         product.UpdatePrice(manager.Id, newPrice, "reason");
 
         // Assert
-        product.DomainEvents.OfType<PriceUpdated>().Should().ContainSingle();
+        product.DomainEvents.OfType<PriceUpdated>().ShouldHaveSingleItem();
     }
 
     [Fact]
@@ -211,7 +215,7 @@ public sealed class ProductTests : UnitTestBase
         var product = Product.Create(_validProduct.Name, _validProduct.Description, _validProduct.Price, _validProduct.UserId).Value;
 
         // Assert
-        product.Status.Should().Be(ProductStatus.Development);
+        product.Status.ShouldBe(ProductStatus.Development);
     }
 
     [Fact]
@@ -224,8 +228,8 @@ public sealed class ProductTests : UnitTestBase
         var result = product.Publish(product.UserId);
 
         // Assert
-        result.IsSuccess.Should().BeTrue();
-        product.Status.Should().Be(ProductStatus.Published);
+        result.IsSuccess.ShouldBeTrue();
+        product.Status.ShouldBe(ProductStatus.Published);
     }
 
     [Fact]
@@ -238,7 +242,7 @@ public sealed class ProductTests : UnitTestBase
         var result = product.Publish(product.UserId);
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
+        result.IsInvalid().ShouldBeTrue();
     }
 
     [Fact]
@@ -251,7 +255,7 @@ public sealed class ProductTests : UnitTestBase
         var result = product.Publish(product.UserId);
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
+        result.IsInvalid().ShouldBeTrue();
     }
 
     [Fact]
@@ -264,7 +268,7 @@ public sealed class ProductTests : UnitTestBase
         var result = product.Publish(Guid.Empty);
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
+        result.IsInvalid().ShouldBeTrue();
     }
 
     [Fact]
@@ -277,7 +281,7 @@ public sealed class ProductTests : UnitTestBase
         product.Publish(product.UserId);
 
         // Assert
-        product.DomainEvents.OfType<ProductPublished>().Should().ContainSingle();
+        product.DomainEvents.OfType<ProductPublished>().ShouldHaveSingleItem();
     }
 
     [Fact]
@@ -290,8 +294,8 @@ public sealed class ProductTests : UnitTestBase
         var result = product.Obsolete(product.UserId);
 
         // Assert
-        result.IsSuccess.Should().BeTrue();
-        product.Status.Should().Be(ProductStatus.Obsolete);
+        result.IsSuccess.ShouldBeTrue();
+        product.Status.ShouldBe(ProductStatus.Obsolete);
     }
 
     [Fact]
@@ -304,8 +308,8 @@ public sealed class ProductTests : UnitTestBase
         var result = product.Obsolete(product.UserId);
 
         // Assert
-        result.IsSuccess.Should().BeTrue();
-        product.Status.Should().Be(ProductStatus.Obsolete);
+        result.IsSuccess.ShouldBeTrue();
+        product.Status.ShouldBe(ProductStatus.Obsolete);
     }
 
     [Fact]
@@ -318,7 +322,7 @@ public sealed class ProductTests : UnitTestBase
         var result = product.Obsolete(product.UserId);
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
+        result.IsInvalid().ShouldBeTrue();
     }
 
     [Fact]
@@ -331,7 +335,7 @@ public sealed class ProductTests : UnitTestBase
         var result = product.Obsolete(Guid.Empty);
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
+        result.IsInvalid().ShouldBeTrue();
     }
 
     [Fact]
@@ -344,7 +348,7 @@ public sealed class ProductTests : UnitTestBase
         product.Obsolete(product.UserId);
 
         // Assert
-        product.DomainEvents.OfType<ProductObsoleted>().Should().ContainSingle();
+        product.DomainEvents.OfType<ProductObsoleted>().ShouldHaveSingleItem();
     }
 
     [Fact]
@@ -358,8 +362,8 @@ public sealed class ProductTests : UnitTestBase
         var result = product.UpdateDescription(product.UserId, newDescription);
 
         // Assert
-        result.IsSuccess.Should().BeTrue();
-        product.Description.Should().Be(newDescription);
+        result.IsSuccess.ShouldBeTrue();
+        product.Description.ShouldBe(newDescription);
     }
 
     [Fact]
@@ -373,7 +377,7 @@ public sealed class ProductTests : UnitTestBase
         var result = product.UpdateDescription(randomUserId, string.Empty);
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
+        result.IsInvalid().ShouldBeTrue();
     }
 
     [Fact]
@@ -388,7 +392,7 @@ public sealed class ProductTests : UnitTestBase
         var result = product.UpdateDescription(emptyUserId, newDescription);
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
+        result.IsInvalid().ShouldBeTrue();
     }
 
     [Fact]
@@ -402,7 +406,7 @@ public sealed class ProductTests : UnitTestBase
         product.UpdateDescription(product.UserId, newDescription);
 
         // Assert
-        product.DomainEvents.OfType<DescriptionUpdated>().Should().ContainSingle();
+        product.DomainEvents.OfType<DescriptionUpdated>().ShouldHaveSingleItem();
     }
 
     [Theory, ClassData(typeof(EmptyStringTestData))]
@@ -415,6 +419,6 @@ public sealed class ProductTests : UnitTestBase
         var result = product.UpdateDescription(product.UserId, newDescription);
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
+        result.IsInvalid().ShouldBeTrue();
     }
 }

--- a/tests/DigitalRightsManagement.UnitTests/UserAggregate/UserTests.cs
+++ b/tests/DigitalRightsManagement.UnitTests/UserAggregate/UserTests.cs
@@ -4,7 +4,7 @@ using DigitalRightsManagement.Domain.UserAggregate.Events;
 using DigitalRightsManagement.Tests.Shared.Factories;
 using DigitalRightsManagement.Tests.Shared.TestData;
 using DigitalRightsManagement.UnitTests.Common.Abstractions;
-using FluentAssertions;
+using Shouldly;
 
 namespace DigitalRightsManagement.UnitTests.UserAggregate;
 
@@ -22,8 +22,9 @@ public sealed class UserTests : UnitTestBase
         var result = User.Create(_user.Username, _user.Email, _user.Role, emptyId);
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
-        result.ValidationErrors.Should().ContainSingle().Which.ErrorCode.Should().Contain("id");
+        result.IsInvalid().ShouldBeTrue();
+        result.ValidationErrors.ShouldHaveSingleItem()
+            .ErrorCode.ShouldContain("id");
     }
 
     [Theory, ClassData(typeof(EmptyStringTestData))]
@@ -34,8 +35,9 @@ public sealed class UserTests : UnitTestBase
         var result = User.Create(emptyUsername, _user.Email, _user.Role);
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
-        result.ValidationErrors.Should().ContainSingle().Which.ErrorCode.Should().Contain("username");
+        result.IsInvalid().ShouldBeTrue();
+        result.ValidationErrors.ShouldHaveSingleItem()
+            .ErrorCode.ShouldContain("username");
     }
 
     [Theory, ClassData(typeof(InvalidEmailTestData))]
@@ -47,8 +49,9 @@ public sealed class UserTests : UnitTestBase
         var result = User.Create(_user.Username, invalidEmail, _user.Role);
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
-        result.ValidationErrors.Should().ContainSingle().Which.ErrorCode.Should().Contain("email");
+        result.IsInvalid().ShouldBeTrue();
+        result.ValidationErrors.ShouldHaveSingleItem()
+            .ErrorCode.ShouldContain("email");
     }
 
     [Fact]
@@ -61,8 +64,9 @@ public sealed class UserTests : UnitTestBase
         var result = User.Create(_user.Username, _user.Email, invalidRole);
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
-        result.ValidationErrors.Should().ContainSingle().Which.ErrorCode.Should().Contain("role");
+        result.IsInvalid().ShouldBeTrue();
+        result.ValidationErrors.ShouldHaveSingleItem()
+            .ErrorCode.ShouldContain("role");
     }
 
     [Fact]
@@ -73,10 +77,10 @@ public sealed class UserTests : UnitTestBase
         var result = User.Create(_user.Username, _user.Email, _user.Role);
 
         // Assert
-        result.IsSuccess.Should().BeTrue();
-        result.Value.Username.Should().Be(_user.Username);
-        result.Value.Email.Should().Be(_user.Email);
-        result.Value.Role.Should().Be(_user.Role);
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Username.ShouldBe(_user.Username);
+        result.Value.Email.ShouldBe(_user.Email);
+        result.Value.Role.ShouldBe(_user.Role);
     }
 
     [Fact]
@@ -87,9 +91,9 @@ public sealed class UserTests : UnitTestBase
         var result = User.Create(_user.Username, _user.Email, _user.Role);
 
         // Assert
-        result.IsSuccess.Should().BeTrue();
-        result.Value.DomainEvents.Should().ContainSingle()
-            .Which.Should().BeOfType<UserCreated>();
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.DomainEvents.ShouldHaveSingleItem()
+            .ShouldBeOfType<UserCreated>();
     }
 
     [Theory, ClassData(typeof(InvalidEmailTestData))]
@@ -102,8 +106,9 @@ public sealed class UserTests : UnitTestBase
         var result = user.ChangeEmail(invalidEmail);
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
-        result.ValidationErrors.Should().ContainSingle().Which.ErrorCode.Should().Contain("email");
+        result.IsInvalid().ShouldBeTrue();
+        result.ValidationErrors.ShouldHaveSingleItem()
+            .ErrorCode.ShouldContain("email");
     }
 
     [Fact]
@@ -116,8 +121,8 @@ public sealed class UserTests : UnitTestBase
         var result = user.ChangeEmail(_user.Email);
 
         // Assert
-        result.IsSuccess.Should().BeTrue();
-        user.Email.Should().Be(_user.Email);
+        result.IsSuccess.ShouldBeTrue();
+        user.Email.ShouldBe(_user.Email);
     }
 
     [Fact]
@@ -130,8 +135,8 @@ public sealed class UserTests : UnitTestBase
         var result = user.ChangeEmail(_user.Email);
 
         // Assert
-        result.IsSuccess.Should().BeTrue();
-        user.DomainEvents.OfType<EmailUpdated>().Should().ContainSingle();
+        result.IsSuccess.ShouldBeTrue();
+        user.DomainEvents.OfType<EmailUpdated>().ShouldHaveSingleItem();
     }
 
     [Fact]
@@ -147,8 +152,8 @@ public sealed class UserTests : UnitTestBase
         var result = user.ChangeRole(admin, targetRole);
 
         // Assert
-        result.IsSuccess.Should().BeTrue();
-        user.Role.Should().Be(targetRole);
+        result.IsSuccess.ShouldBeTrue();
+        user.Role.ShouldBe(targetRole);
     }
 
     [Fact]
@@ -164,8 +169,8 @@ public sealed class UserTests : UnitTestBase
         var result = user.ChangeRole(admin, targetRole);
 
         // Assert
-        result.IsSuccess.Should().BeTrue();
-        user.Role.Should().Be(targetRole);
+        result.IsSuccess.ShouldBeTrue();
+        user.Role.ShouldBe(targetRole);
     }
 
     [Fact]
@@ -179,8 +184,8 @@ public sealed class UserTests : UnitTestBase
         var result = user.ChangeRole(admin, UserRoles.Manager);
 
         // Assert
-        result.IsSuccess.Should().BeTrue();
-        user.DomainEvents.OfType<UserPromoted>().Should().ContainSingle();
+        result.IsSuccess.ShouldBeTrue();
+        user.DomainEvents.OfType<UserPromoted>().ShouldHaveSingleItem();
     }
 
     [Fact]
@@ -201,7 +206,7 @@ public sealed class UserTests : UnitTestBase
             .Select(tuple => tuple.Promotee.ChangeRole(tuple.Promoter, UserRoles.Manager));
 
         // Assert
-        results.Should().AllSatisfy(r => r.IsUnauthorized());
+        results.ShouldAllBe(r => r.IsUnauthorized());
     }
 
     [Fact]
@@ -215,7 +220,7 @@ public sealed class UserTests : UnitTestBase
         var result = user.ChangeRole(admin, UserRoles.Manager);
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
+        result.IsInvalid().ShouldBeTrue();
     }
 
     [Fact]
@@ -229,7 +234,7 @@ public sealed class UserTests : UnitTestBase
         var result = user.ChangeRole(admin, (UserRoles)999);
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
+        result.IsInvalid().ShouldBeTrue();
     }
 
     [Fact]
@@ -243,8 +248,9 @@ public sealed class UserTests : UnitTestBase
         var result = user.AddProduct(product.Id);
 
         // Assert
-        result.IsSuccess.Should().BeTrue();
-        user.Products.Should().ContainSingle().Which.Should().Be(product.Id);
+        result.IsSuccess.ShouldBeTrue();
+        user.Products.ShouldHaveSingleItem()
+            .ShouldBe(product.Id);
     }
 
     [Fact]
@@ -258,7 +264,7 @@ public sealed class UserTests : UnitTestBase
         var result = user.AddProduct(product.Id);
 
         // Assert
-        result.IsUnauthorized().Should().BeTrue();
+        result.IsUnauthorized().ShouldBeTrue();
     }
 
     [Fact]
@@ -272,12 +278,12 @@ public sealed class UserTests : UnitTestBase
         var result = user.AddProduct(product.Id);
 
         // Assert
-        result.IsSuccess.Should().BeTrue();
+        result.IsSuccess.ShouldBeTrue();
 
         // Act
         result = user.AddProduct(product.Id);
 
         // Assert
-        result.IsInvalid().Should().BeTrue();
+        result.IsInvalid().ShouldBeTrue();
     }
 }

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,15 @@
+<Project>
+
+	<PropertyGroup>
+		<ParentDirectoryBuildPropsPath>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))</ParentDirectoryBuildPropsPath>
+	</PropertyGroup>
+
+	<ImportGroup>
+		<Import Project="$(ParentDirectoryBuildPropsPath)" />
+	</ImportGroup>
+
+
+	<ItemGroup>
+		<PackageReference Include="Shouldly" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
+	</ItemGroup>
+</Project>


### PR DESCRIPTION
Switch to Shouldly for assertions in tests

- Added `Shouldly` package version `4.3.0` to `Directory.Packages.props`.
- Replaced `FluentAssertions` with `Shouldly` in `ProductTests.cs` and `UserTests.cs`.
- Removed `FluentAssertions` references from `DigitalRightsManagement.Tests.Shared.csproj`.
- Introduced `Directory.Build.props` to ensure `Shouldly` is available across the solution.

#### PR Classification
Refactor testing framework to consolidate assertion libraries.

#### PR Summary
This pull request replaces `FluentAssertions` with `Shouldly` across the test suite, streamlining assertion methods and reducing dependencies. 
- `ProductTests.cs` and `UserTests.cs`: Replaced `FluentAssertions` assertions with `Shouldly` equivalents.
- `DigitalRightsManagement.Tests.Shared.csproj`: Removed references to `FluentAssertions` and its analyzers.
- `Directory.Packages.props`: Added `Shouldly` package version `4.3.0`.
- `Directory.Build.props`: Updated to include `Shouldly` with `PrivateAssets="all"`.
