### PR TITLE
Query separation

### DIFF
--- a/src/DigitalRightsManagement.Application/Persistence/IManagementQueries.cs
+++ b/src/DigitalRightsManagement.Application/Persistence/IManagementQueries.cs
@@ -1,0 +1,9 @@
+﻿using Ardalis.Result;
+using DigitalRightsManagement.Domain.UserAggregate;
+
+namespace DigitalRightsManagement.Application.Persistence;
+
+public interface IManagementQueries
+{
+    Task<Result<User>> GetById(Guid id, CancellationToken cancellationToken);
+}

--- a/src/DigitalRightsManagement.Application/Persistence/IManagementQueries.cs
+++ b/src/DigitalRightsManagement.Application/Persistence/IManagementQueries.cs
@@ -1,9 +1,9 @@
 ﻿using Ardalis.Result;
-using DigitalRightsManagement.Domain.UserAggregate;
+using DigitalRightsManagement.Domain.ProductAggregate;
 
 namespace DigitalRightsManagement.Application.Persistence;
 
 public interface IManagementQueries
 {
-    Task<Result<User>> GetById(Guid id, CancellationToken cancellationToken);
+    Task<Result<IReadOnlyList<Product>>> GetProductsByUserId(Guid userId, CancellationToken cancellationToken);
 }

--- a/src/DigitalRightsManagement.Infrastructure/InfrastructureDependencyInjection.cs
+++ b/src/DigitalRightsManagement.Infrastructure/InfrastructureDependencyInjection.cs
@@ -39,7 +39,8 @@ public static class InfrastructureDependencyInjection
             .AddScoped<ResourceRepository>()
             .AddScoped<IResourceRepository>(provider =>
             {
-                var resourceRepository = provider.GetRequiredService<ResourceRepository>();
+                var dbContext = provider.GetRequiredService<ManagementDbContext>();
+                var resourceRepository = new ResourceRepository(dbContext);
                 var cache = provider.GetRequiredService<IDistributedCache>();
 
                 return new CachedResourceRepository(resourceRepository, cache);

--- a/src/DigitalRightsManagement.Infrastructure/InfrastructureDependencyInjection.cs
+++ b/src/DigitalRightsManagement.Infrastructure/InfrastructureDependencyInjection.cs
@@ -48,7 +48,7 @@ public static class InfrastructureDependencyInjection
 
     public static THostBuilder AddMigrationInfrastructure<THostBuilder>(this THostBuilder builder) where THostBuilder : IHostApplicationBuilder
     {
-        builder.AddNpgsqlDbContext<ApplicationDbContext>(ResourceNames.Database, settings => settings.DisableRetry = true);
+        builder.AddNpgsqlDbContext<ManagementDbContext>(ResourceNames.Database, settings => settings.DisableRetry = true);
         builder.AddNpgsqlDbContext<AuthDbContext>(ResourceNames.Database, settings => settings.DisableRetry = true);
 
         builder.Services.AddScoped<IApplicationDbManager, ApplicationDbManager>();
@@ -58,7 +58,7 @@ public static class InfrastructureDependencyInjection
             .AddRoles<IdentityRole>()
             .AddEntityFrameworkStores<AuthDbContext>();
 
-        // We only need the services for the ApplicationDbContext
+        // We only need the services for the ManagementDbContext
         builder.Services.AddMediatR(configuration => configuration.RegisterServicesFromAssemblyContaining<AggregateRoot>());
 
         return builder;

--- a/src/DigitalRightsManagement.Infrastructure/InfrastructureDependencyInjection.cs
+++ b/src/DigitalRightsManagement.Infrastructure/InfrastructureDependencyInjection.cs
@@ -33,10 +33,9 @@ public static class InfrastructureDependencyInjection
     private static IServiceCollection AddRepositories(this IServiceCollection services)
     {
         // TODO: Add option to use cache or not
-        return services
+        services
             .AddScoped<IUserRepository, UserRepository>()
             .AddScoped<IProductRepository, ProductRepository>()
-            .AddScoped<ResourceRepository>()
             .AddScoped<IResourceRepository>(provider =>
             {
                 var dbContext = provider.GetRequiredService<ManagementDbContext>();
@@ -45,6 +44,8 @@ public static class InfrastructureDependencyInjection
 
                 return new CachedResourceRepository(resourceRepository, cache);
             });
+
+        return services.AddScoped<IManagementQueries, ManagementQueries>();
     }
 
     public static THostBuilder AddMigrationInfrastructure<THostBuilder>(this THostBuilder builder) where THostBuilder : IHostApplicationBuilder

--- a/src/DigitalRightsManagement.Infrastructure/Messaging/Behaviors/TransactionBehavior.cs
+++ b/src/DigitalRightsManagement.Infrastructure/Messaging/Behaviors/TransactionBehavior.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 namespace DigitalRightsManagement.Infrastructure.Messaging.Behaviors;
 
 internal sealed class TransactionBehavior<TRequest, TResponse>(
-    ApplicationDbContext dbContext,
+    ManagementDbContext dbContext,
     ILogger<TransactionBehavior<TRequest, TResponse>> logger)
     : IPipelineBehavior<TRequest, TResponse>
     where TRequest : IRequest<TResponse>

--- a/src/DigitalRightsManagement.Infrastructure/Messaging/PublisherExtensions.cs
+++ b/src/DigitalRightsManagement.Infrastructure/Messaging/PublisherExtensions.cs
@@ -6,7 +6,7 @@ namespace DigitalRightsManagement.Infrastructure.Messaging;
 
 internal static class PublisherExtensions
 {
-    public static async Task PublishDomainEvents(this IPublisher publisher, ApplicationDbContext dbContext, CancellationToken cancellationToken)
+    public static async Task PublishDomainEvents(this IPublisher publisher, ManagementDbContext dbContext, CancellationToken cancellationToken)
     {
         var domainEvents = dbContext.ChangeTracker.Entries<AggregateRoot>()
             .SelectMany(e => e.Entity.PopDomainEvents());

--- a/src/DigitalRightsManagement.Infrastructure/Persistence/DbManagement/ApplicationDbManager.cs
+++ b/src/DigitalRightsManagement.Infrastructure/Persistence/DbManagement/ApplicationDbManager.cs
@@ -9,7 +9,7 @@ public interface IApplicationDbManager : IDatabaseManager
     void SetSeedData(IEnumerable<User> users, IEnumerable<Product> products);
 }
 
-internal sealed class ApplicationDbManager(ApplicationDbContext dbContext) : DatabaseManager<ApplicationDbContext>(dbContext), IApplicationDbManager
+internal sealed class ApplicationDbManager(ManagementDbContext dbContext) : DatabaseManager<ManagementDbContext>(dbContext), IApplicationDbManager
 {
     private User[] _users = [];
     private Product[] _products = [];

--- a/src/DigitalRightsManagement.Infrastructure/Persistence/ManagementDbContext.cs
+++ b/src/DigitalRightsManagement.Infrastructure/Persistence/ManagementDbContext.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DigitalRightsManagement.Infrastructure.Persistence;
 
-internal sealed class ApplicationDbContext(IPublisher publisher, DbContextOptions<ApplicationDbContext> options) : DbContext(options), IUnitOfWork
+internal sealed class ManagementDbContext(IPublisher publisher, DbContextOptions<ManagementDbContext> options) : DbContext(options), IUnitOfWork
 {
     public DbSet<User> Users => Set<User>();
     public DbSet<Product> Products => Set<Product>();

--- a/src/DigitalRightsManagement.Infrastructure/Persistence/ManagementQueries.cs
+++ b/src/DigitalRightsManagement.Infrastructure/Persistence/ManagementQueries.cs
@@ -1,18 +1,17 @@
 ﻿using Ardalis.Result;
 using DigitalRightsManagement.Application.Persistence;
-using DigitalRightsManagement.Domain.UserAggregate;
+using DigitalRightsManagement.Domain.ProductAggregate;
 using Microsoft.EntityFrameworkCore;
 
 namespace DigitalRightsManagement.Infrastructure.Persistence;
 
 internal sealed class ManagementQueries(ManagementDbContext dbContext) : IManagementQueries
 {
-    public async Task<Result<User>> GetById(Guid id, CancellationToken cancellationToken)
+    public async Task<Result<IReadOnlyList<Product>>> GetProductsByUserId(Guid userId, CancellationToken cancellationToken)
     {
-        var user = await dbContext.Users
-            .AsNoTracking()
-            .FirstOrDefaultAsync(user => user.Id == id, cancellationToken: cancellationToken);
-
-        return user ?? Result<User>.NotFound();
+        return await dbContext.Products
+            .Where(product => product.UserId == userId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
     }
 }

--- a/src/DigitalRightsManagement.Infrastructure/Persistence/ManagementQueries.cs
+++ b/src/DigitalRightsManagement.Infrastructure/Persistence/ManagementQueries.cs
@@ -1,0 +1,18 @@
+﻿using Ardalis.Result;
+using DigitalRightsManagement.Application.Persistence;
+using DigitalRightsManagement.Domain.UserAggregate;
+using Microsoft.EntityFrameworkCore;
+
+namespace DigitalRightsManagement.Infrastructure.Persistence;
+
+internal sealed class ManagementQueries(ManagementDbContext dbContext) : IManagementQueries
+{
+    public async Task<Result<User>> GetById(Guid id, CancellationToken cancellationToken)
+    {
+        var user = await dbContext.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(user => user.Id == id, cancellationToken: cancellationToken);
+
+        return user ?? Result<User>.NotFound();
+    }
+}

--- a/src/DigitalRightsManagement.Infrastructure/Persistence/Migrations/20241226185039_InitialCreate.Designer.cs
+++ b/src/DigitalRightsManagement.Infrastructure/Persistence/Migrations/20241226185039_InitialCreate.Designer.cs
@@ -11,7 +11,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace DigitalRightsManagement.Infrastructure.Migrations
 {
-    [DbContext(typeof(ApplicationDbContext))]
+    [DbContext(typeof(ManagementDbContext))]
     [Migration("20241226185039_InitialCreate")]
     partial class InitialCreate
     {

--- a/src/DigitalRightsManagement.Infrastructure/Persistence/Migrations/20241228211819_AddProduct.Designer.cs
+++ b/src/DigitalRightsManagement.Infrastructure/Persistence/Migrations/20241228211819_AddProduct.Designer.cs
@@ -11,7 +11,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace DigitalRightsManagement.Infrastructure.Migrations
 {
-    [DbContext(typeof(ApplicationDbContext))]
+    [DbContext(typeof(ManagementDbContext))]
     [Migration("20241228211819_AddProduct")]
     partial class AddProduct
     {

--- a/src/DigitalRightsManagement.Infrastructure/Persistence/Migrations/20241228213258_LimitStringLength.Designer.cs
+++ b/src/DigitalRightsManagement.Infrastructure/Persistence/Migrations/20241228213258_LimitStringLength.Designer.cs
@@ -11,7 +11,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace DigitalRightsManagement.Infrastructure.Migrations
 {
-    [DbContext(typeof(ApplicationDbContext))]
+    [DbContext(typeof(ManagementDbContext))]
     [Migration("20241228213258_LimitStringLength")]
     partial class LimitStringLength
     {

--- a/src/DigitalRightsManagement.Infrastructure/Persistence/Migrations/20241228221549_ChangeCreatedByToManagerInProduct.Designer.cs
+++ b/src/DigitalRightsManagement.Infrastructure/Persistence/Migrations/20241228221549_ChangeCreatedByToManagerInProduct.Designer.cs
@@ -11,7 +11,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace DigitalRightsManagement.Infrastructure.Migrations
 {
-    [DbContext(typeof(ApplicationDbContext))]
+    [DbContext(typeof(ManagementDbContext))]
     [Migration("20241228221549_ChangeCreatedByToManagerInProduct")]
     partial class ChangeCreatedByToManagerInProduct
     {

--- a/src/DigitalRightsManagement.Infrastructure/Persistence/Migrations/20241231185301_AddProductsToUser.Designer.cs
+++ b/src/DigitalRightsManagement.Infrastructure/Persistence/Migrations/20241231185301_AddProductsToUser.Designer.cs
@@ -11,7 +11,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace DigitalRightsManagement.Infrastructure.Migrations
 {
-    [DbContext(typeof(ApplicationDbContext))]
+    [DbContext(typeof(ManagementDbContext))]
     [Migration("20241231185301_AddProductsToUser")]
     partial class AddProductsToUser
     {

--- a/src/DigitalRightsManagement.Infrastructure/Persistence/Migrations/20250123183901_ChangeNameOfProductOwnerColumn.Designer.cs
+++ b/src/DigitalRightsManagement.Infrastructure/Persistence/Migrations/20250123183901_ChangeNameOfProductOwnerColumn.Designer.cs
@@ -11,7 +11,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace DigitalRightsManagement.Infrastructure.Migrations
 {
-    [DbContext(typeof(ApplicationDbContext))]
+    [DbContext(typeof(ManagementDbContext))]
     [Migration("20250123183901_ChangeNameOfProductOwnerColumn")]
     partial class ChangeNameOfProductOwnerColumn
     {

--- a/src/DigitalRightsManagement.Infrastructure/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/src/DigitalRightsManagement.Infrastructure/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -10,7 +10,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace DigitalRightsManagement.Infrastructure.Migrations
 {
-    [DbContext(typeof(ApplicationDbContext))]
+    [DbContext(typeof(ManagementDbContext))]
     partial class ApplicationDbContextModelSnapshot : ModelSnapshot
     {
         protected override void BuildModel(ModelBuilder modelBuilder)

--- a/src/DigitalRightsManagement.Infrastructure/Persistence/PersistenceDependencyInjection.cs
+++ b/src/DigitalRightsManagement.Infrastructure/Persistence/PersistenceDependencyInjection.cs
@@ -11,7 +11,7 @@ internal static class PersistenceDependencyInjection
     public static THostBuilder AddPersistence<THostBuilder>(this THostBuilder builder) where THostBuilder : IHostApplicationBuilder
     {
         // BUG: AddNpgsqlDbContext registers the DbContext as singleton, creating problems injecting domain event handler dependencies
-        builder.Services.AddDbContext<ApplicationDbContext>(options =>
+        builder.Services.AddDbContext<ManagementDbContext>(options =>
         {
             options.UseNpgsql(builder.Configuration.GetConnectionString(ResourceNames.Database));
             options.EnableDetailedErrors();

--- a/src/DigitalRightsManagement.Infrastructure/Persistence/Repositories/ProductRepository.cs
+++ b/src/DigitalRightsManagement.Infrastructure/Persistence/Repositories/ProductRepository.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DigitalRightsManagement.Infrastructure.Persistence.Repositories;
 
-internal sealed class ProductRepository(ApplicationDbContext context) : IProductRepository
+internal sealed class ProductRepository(ManagementDbContext context) : IProductRepository
 {
     public IUnitOfWork UnitOfWork => context;
 

--- a/src/DigitalRightsManagement.Infrastructure/Persistence/Repositories/ResourceRepository.cs
+++ b/src/DigitalRightsManagement.Infrastructure/Persistence/Repositories/ResourceRepository.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DigitalRightsManagement.Infrastructure.Persistence.Repositories;
 
-internal class ResourceRepository(ApplicationDbContext dbContext) : IResourceRepository
+internal class ResourceRepository(ManagementDbContext dbContext) : IResourceRepository
 {
     public async Task<bool> IsResourceOwner(Guid userId, Type resourceType, Guid[] resourceIds, CancellationToken ct)
     {

--- a/src/DigitalRightsManagement.Infrastructure/Persistence/Repositories/UserRepository.cs
+++ b/src/DigitalRightsManagement.Infrastructure/Persistence/Repositories/UserRepository.cs
@@ -4,7 +4,7 @@ using DigitalRightsManagement.Domain.UserAggregate;
 
 namespace DigitalRightsManagement.Infrastructure.Persistence.Repositories;
 
-internal sealed class UserRepository(ApplicationDbContext context) : IUserRepository
+internal sealed class UserRepository(ManagementDbContext context) : IUserRepository
 {
     public IUnitOfWork UnitOfWork => context;
 

--- a/tests/DigitalRightsManagement.IntegrationTests/Helpers/Abstractions/ApiIntegrationTestsBase.cs
+++ b/tests/DigitalRightsManagement.IntegrationTests/Helpers/Abstractions/ApiIntegrationTestsBase.cs
@@ -15,14 +15,14 @@ public abstract class ApiIntegrationTestsBase : IClassFixture<ApiFixture>, IAsyn
 
     protected readonly ApiFixture Fixture;
 
-    internal ApplicationDbContext DbContext { get; }
+    internal ManagementDbContext DbContext { get; }
 
     protected ApiIntegrationTestsBase(ApiFixture fixture)
     {
         Fixture = fixture;
         _scope = Fixture.Services.CreateScope();
 
-        DbContext = _scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        DbContext = _scope.ServiceProvider.GetRequiredService<ManagementDbContext>();
     }
 
     protected HttpClient GetHttpClient(User user)

--- a/tests/DigitalRightsManagement.IntegrationTests/Messaging/Behaviors/TransactionBehaviorTests.cs
+++ b/tests/DigitalRightsManagement.IntegrationTests/Messaging/Behaviors/TransactionBehaviorTests.cs
@@ -14,13 +14,13 @@ namespace DigitalRightsManagement.IntegrationTests.Messaging.Behaviors;
 public sealed class TransactionBehaviorTests : ApiIntegrationTestsBase
 {
     private readonly IServiceScope _scope;
-    private readonly ApplicationDbContext _transactionDbContext;
+    private readonly ManagementDbContext _transactionDbContext;
     private readonly TransactionBehavior<TestRequest, Result> _behavior;
 
     public TransactionBehaviorTests(ApiFixture fixture) : base(fixture)
     {
         _scope = fixture.Services.CreateScope();
-        _transactionDbContext = _scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        _transactionDbContext = _scope.ServiceProvider.GetRequiredService<ManagementDbContext>();
         var logger = _scope.ServiceProvider.GetRequiredService<ILogger<TransactionBehavior<TestRequest, Result>>>();
         _behavior = new TransactionBehavior<TestRequest, Result>(_transactionDbContext, logger);
     }


### PR DESCRIPTION
#### PR Classification
Refactor to rename database context and introduce new query interface.

#### PR Summary
This pull request renames `ApplicationDbContext` to `ManagementDbContext` throughout the application and introduces a new interface for managing product queries. 
- **IManagementQueries.cs**: Added interface for retrieving products by user ID.
- **InfrastructureDependencyInjection.cs**: Updated dependency injection to register `ManagementDbContext` and related services.
- **TransactionBehavior.cs**: Changed to use `ManagementDbContext` instead of `ApplicationDbContext`.
- **ProductRepository.cs**: Refactored to use `ManagementDbContext`.
- **Migration files**: Updated to reference `ManagementDbContext` instead of `ApplicationDbContext`.
