### PR TITLE
Refactor worker seeding in assignment test

### DIFF
--- a/tests/DigitalRightsManagement.IntegrationTests/ProductAggregate/ProductTests.cs
+++ b/tests/DigitalRightsManagement.IntegrationTests/ProductAggregate/ProductTests.cs
@@ -157,7 +157,7 @@ public sealed class ProductTests(ApiFixture fixture) : ApiIntegrationTestsBase(f
         // Arrange
         var manager = AgentFactory.Seeded(user => user.Products.Count > 0 && user.Role == AgentRoles.Manager);
         var productId = manager.Products[0];
-        var worker = AgentFactory.Seeded(AgentRoles.Worker);
+        var worker = AgentFactory.Seeded(worker => !worker.Products.Contains(productId));
 
         var assignWorkerDto = new AssignWorkerDto(worker.Id);
 


### PR DESCRIPTION
Refactor worker seeding in assignment test

Updated the `Assign_Worker_Happy_Path` test method to seed a worker only if they do not already have the specified product. This change enhances the accuracy of the assignment logic being tested.